### PR TITLE
セキュアアクセスでも機能を使えるようにする

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,12 +11,16 @@
   "permissions": [
     "storage",
     "https://bozuman.cybozu.com/*",
+    "https://bozuman.s.cybozu.com/*",
     "tabs",
     "background",
     "contextMenus"
   ],
   "content_scripts": [{
-    "matches": ["https://bozuman.cybozu.com/*"],
+    "matches": [
+      "https://bozuman.cybozu.com/*",
+      "https://bozuman.s.cybozu.com/*"
+    ],
     "js": [
       "js/moment.js",
       "js/jquery-3.2.1.min.js",
@@ -31,7 +35,10 @@
     ]
   }],
   "background": {
-    "matches": ["https://bozuman.cybozu.com/*"],
+    "matches": [
+      "https://bozuman.cybozu.com/*",
+      "https://bozuman.s.cybozu.com/*"
+    ],
     "scripts": [
       "js/jquery-3.2.1.min.js",
       "js/background.js"


### PR DESCRIPTION
[現状]
https://{subdomain}.cybozu.com/ ではスケジュールピッカー機能が使えるが、 https://{subdomain}.s.cybozu.com/ では使えない。

[やりたいこと]
https://{subdomain}.s.cybozu.com/ でもスケジュールピッカー機能を使いたい。

[やったこと]
manifest.json にセキュアアクセスのURL `https://{subdomain}.s.cybozu.com/*` を追加する。